### PR TITLE
Compiler passes have lowest priority

### DIFF
--- a/DependencyInjection/CompilerPass/PreloadNamespacesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PreloadNamespacesCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/CompilerPass/PreloadServicesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PreloadServicesCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/PreloadConfiguration.php
+++ b/DependencyInjection/PreloadConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/PreloadExtension.php
+++ b/DependencyInjection/PreloadExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Event/PreloadServicesCollector.php
+++ b/Event/PreloadServicesCollector.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Drift Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
 namespace Drift\Preload\Event;
 
 use Drift\HttpKernel\Event\PreloadEvent;

--- a/Exception/InvalidPresetException.php
+++ b/Exception/InvalidPresetException.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Drift Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
 namespace Drift\Preload\Exception;
 
 use Exception;

--- a/PreloadBundle.php
+++ b/PreloadBundle.php
@@ -1,12 +1,26 @@
 <?php
 
+/*
+ * This file is part of the Drift Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
 namespace Drift\Preload;
 
 use Drift\Preload\DependencyInjection\CompilerPass\PreloadNamespacesCompilerPass;
 use Drift\Preload\DependencyInjection\CompilerPass\PreloadServicesCompilerPass;
 use Drift\Preload\DependencyInjection\PreloadExtension;
 use Mmoreram\BaseBundle\BaseBundle;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
@@ -15,16 +29,16 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 class PreloadBundle extends BaseBundle
 {
     /**
-     * Return a CompilerPass instance array.
+     * Builds bundle.
      *
-     * @return CompilerPassInterface[]
+     * @param ContainerBuilder $container Container
      */
-    public function getCompilerPasses(): array
+    public function build(ContainerBuilder $container)
     {
-        return [
-            new PreloadServicesCompilerPass(),
-            new PreloadNamespacesCompilerPass(),
-        ];
+        parent::build($container);
+
+        $container->addCompilerPass(new PreloadServicesCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
+        $container->addCompilerPass(new PreloadNamespacesCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
     }
 
     /**

--- a/Preset/DriftPreset.php
+++ b/Preset/DriftPreset.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Preset/Preset.php
+++ b/Preset/Preset.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Preset/ReactPreset.php
+++ b/Preset/ReactPreset.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Preset/SymfonyPreset.php
+++ b/Preset/SymfonyPreset.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/AService.php
+++ b/Tests/AService.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Drift Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
 namespace Drift\Preload\Tests;
 
 use Drift\React;

--- a/Tests/PreloadFunctionalTest.php
+++ b/Tests/PreloadFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/PresetsFunctionalTest.php
+++ b/Tests/PresetsFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/ServicesFunctionalTest.php
+++ b/Tests/ServicesFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the Drift Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,8 +15,8 @@ declare(strict_types=1);
 
 namespace Drift\Preload\Tests;
 
-use function Clue\React\Block\await;
 use Drift\Preload\Event\PreloadServicesCollector;
+use function Clue\React\Block\await;
 use function Drift\React\sleep as async_sleep;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;


### PR DESCRIPTION
- Because should be executed after all of them
- PHP Fixed